### PR TITLE
Add 20H2 v2 ISO which is the one served by MS

### DIFF
--- a/Fido.ps1
+++ b/Fido.ps1
@@ -80,6 +80,12 @@ $WindowsVersions = @(
 	@(
 		@("Windows 10", "Windows10ISO"),
 		@(
+			"20H2 v2 (Build 19042.631 - 2020.12)",
+			@("Windows 10 Home/Pro", 1882),
+			@("Windows 10 Education", 1884),
+			@("Windows 10 Home China ", ($zh + 1883))
+		),
+		@(
 			"20H2 (Build 19042.508 - 2020.10)",
 			@("Windows 10 Home/Pro", 1807),
 			@("Windows 10 Education", 1805),


### PR DESCRIPTION
Add 20H2 v2 ISO which is the one served by MS on the Windows 10 ISO download page.