### PR TITLE
Fix null comparison in Fido.ps1

### DIFF
--- a/Fido.ps1
+++ b/Fido.ps1
@@ -772,7 +772,7 @@ if ($Cmd) {
 		}
 		$i++
 	}
-	if ($winVersionId -eq $null) {
+	if ($null -eq $winVersionId) {
 		if ($Win -ne "List") {
 			Write-Host "Invalid Windows version provided."
 			Write-Host "Use '-Win List' for a list of available Windows versions."
@@ -797,7 +797,7 @@ if ($Cmd) {
 			break;
 		}
 	}
-	if ($winReleaseId -eq $null) {
+	if ($null -eq $winReleaseId) {
 		if ($Rel -ne "List") {
 			Write-Host "Invalid Windows release provided."
 			Write-Host "Use '-Rel List' for a list of available $Selected releases or '-Rel Latest' for latest."
@@ -822,7 +822,7 @@ if ($Cmd) {
 			break;
 		}
 	}
-	if ($winEditionId -eq $null) {
+	if ($null -eq $winEditionId) {
 		if ($Ed -ne "List") {
 			Write-Host "Invalid Windows edition provided."
 			Write-Host "Use '-Ed List' for a list of available editions or remove the -Ed parameter to use default."
@@ -887,7 +887,7 @@ if ($Cmd) {
 		}
 		$i++
 	}
-	if ($winLink -eq $null) {
+	if ($null -eq $winLink) { # used left side of equality operator
 		if ($Arch -ne "List") {
 			Write-Host "Invalid Windows architecture provided."
 			Write-Host "Use '-Arch List' for a list of available architectures or remove the option to use system default."


### PR DESCRIPTION
This pull request fixes the null comparison issue in the Fido.ps1 file. The comparison was incorrectly written as `$winVersionId -eq $null`, and it has been corrected to `$null -eq $winVersionId`. This ensures that the comparison is done correctly and resolves the issue.